### PR TITLE
Fix minutes config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lita::Keepalive
 
-TODO: Write a gem description
+Keepalive plugin for Lita and heroku - pings its own route periodically to keep Heroku instance alive.
 
 ## Installation
 
@@ -21,6 +21,13 @@ Or install it yourself as:
 ## Usage
 
 TODO: Write usage instructions here
+
+```ruby
+Lita.configure do |config|
+  config.handlers.keepalive.minutes = 1
+  config.handlers.keepalive.url = 'http://your-lita-robot-name.herokuapp.com'
+end
+```
 
 ## Contributing
 

--- a/lib/lita/handlers/keepalive.rb
+++ b/lib/lita/handlers/keepalive.rb
@@ -10,7 +10,7 @@ module Lita
 
       on(:loaded) do
         log.info "Starting Keepalive to #{config.url}/ping"
-        every(config.minutes) do
+        every(config.minutes * 60) do
           log.info "Keepalive ping..."
           http.get "#{config.url}/ping"
         end


### PR DESCRIPTION
The value of `config.minutes` was being interpreted as seconds
